### PR TITLE
Allow user to pass a users.conf with variables inside

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Adrian Dvergsdal [atmoz.net]
 # - OpenSSH needs /var/run/sshd to run
 # - Remove generic host keys, entrypoint generates unique keys
 RUN apt-get update && \
-    apt-get -y install openssh-server && \
+    apt-get -y install gettext openssh-server && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p /var/run/sshd /etc/ssh.d && \
     rm -f /etc/ssh/ssh_host_*key*

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -6,7 +6,7 @@ MAINTAINER Adrian Dvergsdal [atmoz.net]
 # - OpenSSH needs /var/run/sshd to run
 # - Remove generic host keys, entrypoint generates unique keys
 RUN echo "@community http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
-    apk add --no-cache bash shadow@community openssh-server-pam openssh-sftp-server && \
+    apk add --no-cache bash gettext shadow@community openssh-server-pam openssh-sftp-server && \
     ln -s /usr/sbin/sshd.pam /usr/sbin/sshd && \
     mkdir -p /var/run/sshd /etc/ssh.d && \
     rm -f /etc/ssh/ssh_host_*key*

--- a/files/create-sftp-user
+++ b/files/create-sftp-user
@@ -29,7 +29,6 @@ function validateArg() {
     fi
 }
 
-log "Parsing user data: \"$1\""
 IFS=':' read -ra args <<< "$1"
 
 skipIndex=0

--- a/files/entrypoint
+++ b/files/entrypoint
@@ -9,6 +9,7 @@ reArgSkip='^([[:blank:]]*#.*|[[:blank:]]*)$' # comment or empty line
 
 # Paths
 userConfPath="/etc/sftp/users.conf"
+userConfTmpPath="/etc/sftp/users-tmp.conf"
 userConfPathLegacy="/etc/sftp-users.conf"
 userConfFinalPath="/var/run/sftp/users.conf"
 
@@ -33,7 +34,9 @@ fi
 if [ ! -f "$userConfFinalPath" ]; then
     mkdir -p "$(dirname $userConfFinalPath)"
 
-    if [ -f "$userConfPath" ]; then
+    if [ -f "$userConfTmpPath" ]; then
+        # Replace the variables in the temp file
+        envsubst < $userConfTmpPath > $userConfPath
         # Append mounted config to final config
         grep -v -E "$reArgSkip" < "$userConfPath" > "$userConfFinalPath"
     fi


### PR DESCRIPTION
- `users-tmp.conf` can contain environment variables for a user/password combination
- `envsubst` will run and replace the values from the environment and write the file as `users.conf`
- Remove logging  as it prints out the password

```
# users-tmp.conf
$USER1:$PASSWORD2:1001:100:incoming,outgoing
$USER2:$PASSWORD2:1001:100:incoming,outgoing
```